### PR TITLE
`都道府県别感染人数` に感染人数ボックスを追加

### DIFF
--- a/src/components/InfectRegionGraphDesktop.vue
+++ b/src/components/InfectRegionGraphDesktop.vue
@@ -24,7 +24,9 @@
           <div
             class="region-column"
             v-bind:style="{ height: `${regionData.count / units[0] * 100}%` }"
-          ></div>
+          >
+            <div class="region-count">{{ regionData.count }}</div>
+          </div>
         </div>
       </div>
     </div>
@@ -184,6 +186,31 @@ export default {
     bottom: 0;
     background-color: $color-navy;
     border-radius: 4px 4px 0px 0px;
+    cursor: pointer;
+
+    &:hover {
+      .region-count {
+        opacity: 1;
+      }
+    }
+  }
+
+  .region-count {
+    opacity: 0;
+    position: absolute;
+    width: 100%;
+    top: 0;
+    transform: translateY(calc(-100% - 8px));
+    background-color: #757F8B;
+    color: $color-white;
+    text-align: center;
+    font-size: 12px;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border-radius: 15px;
+    pointer-events: none;
+    transition: opacity .3s ease;
+    word-break: break-all;
   }
 
   .region-label-group {

--- a/src/components/InfectRegionGraphMobile.vue
+++ b/src/components/InfectRegionGraphMobile.vue
@@ -38,7 +38,9 @@
         v-for="regionData in regionDatas"
         v-bind:key="regionData.region"
         v-bind:style="{ width: `${regionData.count / units[0] * 100}%` }"
-      />
+      >
+        <div class="region-count">{{ regionData.count }}</div>
+      </div>
     </div>
   </div>
 </template>
@@ -171,6 +173,30 @@ export default {
     height: 15px;
     background-color: $color-navy;
     border-radius: 0 4px 4px 0px;
+    cursor: pointer;
+
+    &:hover {
+      .region-count {
+        opacity: 1;
+      }
+    }
+  }
+
+  .region-count {
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    transform: translateY(calc(-100% - 2px));
+    background-color: #757F8B;
+    color: $color-white;
+    text-align: center;
+    font-size: 12px;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border-radius: 15px;
+    pointer-events: none;
+    transition: opacity .3s ease;
   }
 
   .unit-group {

--- a/src/toppage/sections/covid19_infect_region.vue
+++ b/src/toppage/sections/covid19_infect_region.vue
@@ -1,7 +1,11 @@
 <template>
   <div id="covid19-infect-region">
-    <InfectRegionGraphDesktop />
-    <InfectRegionGraphMobile />
+    <div class="desktop-graph-wrapper">
+      <InfectRegionGraphDesktop />
+    </div>
+    <div class="mobile-graph-wrapper">
+      <InfectRegionGraphMobile />
+    </div>
   </div>
 </template>
 
@@ -25,6 +29,18 @@ export default {
 @import "@/commons/_variables.scss";
 
 #covid19-infect-region {
-  display: block;
+  .mobile-graph-wrapper {
+    display: none;
+  }
+
+  @media (max-width: 480px) {
+    .mobile-graph-wrapper {
+      display: block;
+    }
+
+    .desktop-graph-wrapper {
+      display: none;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
## 🍦 注意
このPRの向き先は `develop/1010` ブランチです

## 変更点
`都道府県别感染人数` 実装の時に漏れてた感染人数ボックスを追加しました 🙇 

## スクショ
|desktop|
|----|
|<img width="1041" alt="スクリーンショット 2020-03-14 11 33 17" src="https://user-images.githubusercontent.com/7374506/76673424-3e48d500-65e8-11ea-81a4-2b722826060e.png">|

|mobile|
|----|
|<img width="440" alt="スクリーンショット 2020-03-14 11 32 54" src="https://user-images.githubusercontent.com/7374506/76673427-4acd2d80-65e8-11ea-8150-73b18ddbe594.png">|