### PR TITLE
footer 実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5184,6 +5184,14 @@
       "resolved": "https://registry.npm.taobao.org/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "4.6.0",
       "resolved": "https://registry.npm.taobao.org/copy-webpack-plugin/download/copy-webpack-plugin-4.6.0.tgz?cache=0&sync_timestamp=1576145009360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcopy-webpack-plugin%2Fdownload%2Fcopy-webpack-plugin-4.6.0.tgz",
@@ -18049,6 +18057,11 @@
           }
         }
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@vue/cli-service": "^4.2.3",
+    "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.8.22",
     "iview": "^3.5.4",
     "vue": "^2.5.2",

--- a/src/components/AboutServiceBlock.vue
+++ b/src/components/AboutServiceBlock.vue
@@ -1,0 +1,95 @@
+<template>
+  <article id="AboutService">
+    <h3 class="about-service-header">
+      <img
+        class="service-logo"
+        alt="新型コロナウイルス対策"
+        src="../assets/image/logo.svg"
+      />
+
+      <div class="share-panel-desktop-wrapper">
+        <SharePanel />
+      </div>
+    </h3>
+
+    <p class="service-description">
+      日本と中国のウイルス症状や予防対策に対する認識は異なります。
+      当サイトは日本と中国の新型コロナウイルスに関する情報を収集し、まとめて伝えることで、日本で住む方が日中のウイルスの対策を把握できるようにすることを目的としています。
+    </p>
+
+    <div class="share-panel-mobile-wrapper">
+      <h4 class="share-title">シェア</h4>
+      <SharePanel />
+    </div>
+  </article>
+</template>
+
+<script>
+import SharePanel from '@/components/SharePanel';
+
+export default {
+  name: 'AboutServiceBlock',
+  components: { SharePanel },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style  lang="scss" scoped>
+@import "@/commons/_variables.scss";
+$break-point: 480px;
+
+#AboutService {
+  text-align: left;
+  padding: 40px 16px;
+  background-color: $color-palegray;
+
+  .share-panel-mobile-wrapper {
+    display: none;
+  }
+
+  @media (max-width: $break-point) {
+    padding: 30px 16px;
+
+    .share-panel-desktop-wrapper {
+      display: none;
+    }
+
+    .share-panel-mobile-wrapper {
+      display: block;
+    }
+  }
+
+  .about-service-header {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .service-logo {
+    height: 50px;
+
+    @media (max-width: $break-point) {
+      height: 38px;
+    }
+  }
+
+  .service-description {
+    margin: 20px 0 0;
+    font-size: 16px;
+    font-weight: bold;
+    color: $color-darkgray;
+
+    @media (max-width: $break-point) {
+      font-size: 14px;
+    }
+  }
+
+  .share-title {
+    margin: 32px 0 20px;
+    text-align: center;
+    font-size: 16px;
+    font-weight: bold;;
+  }
+}
+</style>

--- a/src/components/AboutTeamTermsOfServiceBlock.vue
+++ b/src/components/AboutTeamTermsOfServiceBlock.vue
@@ -1,0 +1,146 @@
+<template>
+  <div id="AboutTeamTermsOfServiceBlock">
+    <ul class="tab-link-list" role="tablist">
+      <li class="tab-link-wrapper" role="presentation">
+        <a
+          id="about-team-link"
+          href="##about-team-panel"
+          role="tab"
+          aria-controls="about-team-link"
+          v-bind:aria-selcted="isAboutTeamTabActive"
+          class="tab-link"
+          v-on:click="onAboutTeamTabLinkClick"
+          v-bind:class="{ active: isAboutTeamTabActive }"
+        >
+          BitValley-Meliponinae
+        </a>
+      </li>
+      <li class="tab-link-wrapper" role="presentation">
+        <a
+          id="terms-of-service-link"
+          href="##terms-of-service-panel"
+          role="tab"
+          aria-controls="terms-of-service-panel"
+          v-bind:aria-selected="isTermsOfServiceTabActive"
+          class="tab-link"
+          v-on:click="onTermsOfServiceTabClick"
+          v-bind:class="{ active: isTermsOfServiceTabActive }"
+        >
+          利用規約
+        </a>
+      </li>
+    </ul>
+
+    <p
+      id="about-team-panel"
+      aria-labelledby="about-team-link"
+      role="tabpanel"
+      v-bind:aria-hidden="!isAboutTeamTabActive"
+      class="tab-panel"
+      v-bind:class="{ active: isAboutTeamTabActive }"
+    >
+      コロナ対策について、小さくても何か力になりたいと思います。
+      <br />
+      日本に住む皆様が一刻も早く安心して暮らせるよう、心より願っております。
+    </p>
+    <p
+      id="terms-of-service-panel"
+      aria-labelledby="terms-of-service-link"
+      role="tabpanel"
+      v-bind:aria-hidden="!isTermsOfServiceTabActive"
+      class="tab-panel"
+      v-bind:class="{ active: isTermsOfServiceTabActive }"
+    >
+      コロナ対策について、小さくても何か力になりたいと思います。
+      <br />
+      日本に住む皆様が一刻も早く安心して暮らせるよう、心より願っております。
+      <br />
+      コロナ対策について、小さくても何か力になりたいと思います。
+      <br />
+      日本に住む皆様が一刻も早く安心して暮らせるよう、心より願っております。
+      <br />
+      コロナ対策について、小さくても何か力になりたいと思います。
+      <br />
+      日本に住む皆様が一刻も早く安心して暮らせるよう、心より願っております。
+      <br />
+    </p>
+  </div>
+</template>
+
+<script>
+const ABOUT_TEAM_TAB = 'about-team';
+const TERMS_OF_SERVICE_TAB = 'terms-of-service';
+
+export default {
+  name: 'AboutTeamTermServiceBlock',
+  data() {
+    return {
+      activeTab: ABOUT_TEAM_TAB,
+    };
+  },
+  computed: {
+    isAboutTeamTabActive() {
+      return this.activeTab === ABOUT_TEAM_TAB;
+    },
+    isTermsOfServiceTabActive() {
+      return this.activeTab === TERMS_OF_SERVICE_TAB;
+    },
+  },
+  methods: {
+    onAboutTeamTabLinkClick() {
+      this.activeTab = ABOUT_TEAM_TAB;
+    },
+    onTermsOfServiceTabClick() {
+      this.activeTab = TERMS_OF_SERVICE_TAB;
+    },
+  },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style lang="scss" scoped>
+@import "@/commons/_variables.scss";
+
+#AboutTeamTermsOfServiceBlock {
+  background-color: $color-blightgray;
+  padding: 32px 16px;
+
+  .tab-link-list {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .tab-link-wrapper:not(:last-of-type) {
+    padding-right: 16px;
+    margin-right: 16px;
+    border-right: 2px solid $color-palegray;
+  }
+
+  .tab-link {
+    font-size: 16px;
+    font-weight: bold;
+    color: $color-gray;
+
+    &:hover,
+    &.active {
+      color: $color-darkgray;
+    }
+  }
+
+  .tab-panel {
+    margin: 16px 0 0;
+    text-align: center;
+    font-size: 12px;
+    color: $color-darkgray;
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+}
+</style>

--- a/src/components/SharePanel.vue
+++ b/src/components/SharePanel.vue
@@ -1,0 +1,109 @@
+<template>
+  <ul id="SharePanel">
+    <li>
+      <a
+        aria-label="Twitterでシェアする"
+        class="twitter-share"
+        target="_blank"
+        v-bind:href="twitterShareUrl"
+      />
+    </li>
+    <li>
+      <a
+        aria-label="Facebookでシェアする"
+        class="facebook-share"
+        target="_blank"
+        v-bind:href="facebookShareUrl"
+      />
+    </li>
+    <li>
+      <button
+        aria-label="URLをコピーする"
+        type="button"
+        class="link-copy-button"
+        v-on:click="onLinkCopyButtonClick"
+      />
+    </li>
+  </ul>
+</template>
+
+<script>
+import copy from 'copy-to-clipboard';
+
+const SHARE_URL = 'http://www.google.com';
+const SHARE_TEXT = 'シェアしますよーーー';
+
+export default {
+  name: 'SharePanel',
+  computed: {
+    twitterShareUrl() {
+      return `https://twitter.com/intent/tweet?${
+        new URLSearchParams([['url', SHARE_URL], ['text', SHARE_TEXT]])
+      }`;
+    },
+    facebookShareUrl() {
+      return `https://www.facebook.com/sharer/sharer.php?${
+        new URLSearchParams([['u', SHARE_URL]])
+      }`;
+    },
+  },
+  methods: {
+    onLinkCopyButtonClick() {
+      // eslint-disable-next-line no-alert
+      copy(SHARE_URL, { onCopy() { alert('URLをコピーしました'); } });
+    },
+  },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style lang="scss" scoped>
+@import "@/commons/_variables.scss";
+#SharePanel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li:not(:last-of-type) {
+    margin-right: 24px;
+  }
+
+  .twitter-share,
+  .facebook-share,
+  .link-copy-button {
+    display: block;
+    width: 30px;
+    height: 30px;
+    background-color: $color-black;
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    transition: background-color .3s ease;
+
+    &:hover {
+      background-color: $color-blue;
+    }
+  }
+
+  .twitter-share {
+    -webkit-mask-image: url('../assets/image/twitter.svg');
+    mask-image: url('../assets/image/twitter.svg');
+  }
+
+  .facebook-share {
+    -webkit-mask-image: url('../assets/image/facebook.svg');
+    mask-image: url('../assets/image/facebook.svg');
+  }
+
+  .link-copy-button {
+    -webkit-mask-image: url('../assets/image/sharelink.svg');
+    mask-image: url('../assets/image/sharelink.svg');
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    appearance: none;
+  }
+}
+</style>

--- a/src/toppage/covid19_top.vue
+++ b/src/toppage/covid19_top.vue
@@ -83,4 +83,8 @@ a {
 a:hover{
     color: $color-blue;
 }
+
+body {
+  margin: 0;
+}
 </style>

--- a/src/toppage/sections/covid19_footer.vue
+++ b/src/toppage/sections/covid19_footer.vue
@@ -1,12 +1,17 @@
 <template>
-  <div id="covid19-footer">
-    <h2>{{ msg }}</h2>
-  </div>
+  <footer id="covid19-footer">
+    <AboutServiceBlock />
+    <AboutTeamTermsOfServiceBlock />
+  </footer>
 </template>
 
 <script>
+import AboutServiceBlock from '@/components/AboutServiceBlock';
+import AboutTeamTermsOfServiceBlock from '@/components/AboutTeamTermsOfServiceBlock';
+
 export default {
   name: 'Footer',
+  components: { AboutServiceBlock, AboutTeamTermsOfServiceBlock },
   data() {
     return {
       msg: '这里是Footer的页面',
@@ -20,6 +25,6 @@ export default {
 @import "@/commons/_variables.scss";
 
 #covid19-footer {
-  display: flex;
+  display: block;
 }
 </style>


### PR DESCRIPTION
### 🍸 注意
このPRの向き先は `develop/1010` です

### 変更点
footer を実装してみましたー

### 相談
今回追加した `src/components/SharePanel.vue` は header に流用できそうですか？

### スクショ
|desktop|
|----|
|<img width="946" alt="スクリーンショット 2020-03-15 18 55 56" src="https://user-images.githubusercontent.com/7374506/76699378-29efff80-66f0-11ea-8c72-a603b6a40c06.png">|

|mobile|
|----|
|<img width="403" alt="スクリーンショット 2020-03-15 18 55 43" src="https://user-images.githubusercontent.com/7374506/76699379-2bb9c300-66f0-11ea-98a8-a8495dc81f00.png">|