### PR TITLE
趙担当部分のデザイン諸々修正

### DIFF
--- a/src/components/AboutServiceBlock.vue
+++ b/src/components/AboutServiceBlock.vue
@@ -75,21 +75,19 @@ $break-point: 480px;
   }
 
   .service-description {
+    @include noto-font-001em(16px, normal);
     margin: 20px 0 0;
-    font-size: 16px;
-    font-weight: bold;
     color: $color-darkgray;
 
     @media (max-width: $break-point) {
-      font-size: 14px;
+      @include noto-font-001em(14px, normal);
     }
   }
 
   .share-title {
+    @include noto-font-001em(16px, bold);
     margin: 32px 0 20px;
     text-align: center;
-    font-size: 16px;
-    font-weight: bold;;
   }
 }
 </style>

--- a/src/components/AboutTeamTermsOfServiceBlock.vue
+++ b/src/components/AboutTeamTermsOfServiceBlock.vue
@@ -121,8 +121,7 @@ export default {
   }
 
   .tab-link {
-    font-size: 16px;
-    font-weight: bold;
+    @include noto-font-001em(16px, bold);
     color: $color-gray;
 
     &:hover,
@@ -132,9 +131,9 @@ export default {
   }
 
   .tab-panel {
+    @include noto-font-001em(12px, normal);
     margin: 16px 0 0;
     text-align: center;
-    font-size: 12px;
     color: $color-darkgray;
     display: none;
 

--- a/src/components/InfectRegionGraphDesktop.vue
+++ b/src/components/InfectRegionGraphDesktop.vue
@@ -148,9 +148,8 @@ export default {
   margin: 24px;
 
   .unit-group {
+    @include noto-font-001em(10px, bold);
     text-align: left;
-    font-weight: bold;
-    font-size: 10px;
     color: $color-gray;
   }
 
@@ -196,6 +195,7 @@ export default {
   }
 
   .region-count {
+    @include noto-font-001em(12px, normal);
     opacity: 0;
     position: absolute;
     width: 100%;
@@ -204,7 +204,6 @@ export default {
     background-color: #757F8B;
     color: $color-white;
     text-align: center;
-    font-size: 12px;
     box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 15px;
@@ -219,8 +218,7 @@ export default {
   }
 
   .region-label {
-    font-weight: bold;
-    font-size: 10px;
+    @include noto-font-001em(10px, bold);
     color: $color-gray;
     text-align: center;
     padding: 0 4px;

--- a/src/components/InfectRegionGraphMobile.vue
+++ b/src/components/InfectRegionGraphMobile.vue
@@ -148,8 +148,7 @@ export default {
   margin: 24px;
 
   .region-label {
-    font-weight: bold;
-    font-size: 10px;
+    @include noto-font-001em(10px, bold);
     color: $color-gray;
     text-align: left;
     margin: 8px 0;
@@ -183,6 +182,7 @@ export default {
   }
 
   .region-count {
+    @include noto-font-001em(12px, normal);
     opacity: 0;
     position: absolute;
     top: 0;
@@ -191,7 +191,6 @@ export default {
     background-color: #757F8B;
     color: $color-white;
     text-align: center;
-    font-size: 12px;
     box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 15px;
@@ -205,10 +204,9 @@ export default {
   }
 
   .unit {
+    @include noto-font-001em(10px, bold);
     top: 0;
     position: absolute;
-    font-weight: bold;
-    font-size: 10px;
     color: $color-gray;
     text-align: right;
   }

--- a/src/components/NewsListBlock.vue
+++ b/src/components/NewsListBlock.vue
@@ -182,18 +182,16 @@ $break-point: 960px;
   }
 
   .date {
-    font-size: 16px;
-    font-weight: bold;
+    @include noto-font-001em(16px, bold);
   }
 
   .time {
-    font-size: 14px;
+    @include noto-font-001em(16px, normal);
   }
 
   @media (max-width: $break-point) {
     .date, .time {
-      font-size: 14px;
-      font-weight: bold;
+      @include noto-font-001em(14px, bold);
     }
 
     .time {
@@ -288,11 +286,10 @@ $break-point: 960px;
   }
 
   .articleTitle {
+    @include noto-font-001em(16px, bold);
     display: flex;
     justify-content: space-between;
     align-items: center;
-    font-size: 16px;
-    font-weight: bold;
     margin: 0;
   }
 
@@ -306,7 +303,7 @@ $break-point: 960px;
   }
 
   .articleText {
-    font-size: 12px;
+    @include noto-font-001em(12px, normal);
     color: $color-gray;
     display: -webkit-box;
     -webkit-line-clamp: 2;

--- a/src/components/NewsListBlock.vue
+++ b/src/components/NewsListBlock.vue
@@ -278,10 +278,6 @@ $break-point: 960px;
       .linkArrow path {
         stroke: $color-blue;
       }
-
-      .articleText {
-        color: $color-blue;
-      }
     }
   }
 

--- a/src/components/PreventMeasureTabLink.vue
+++ b/src/components/PreventMeasureTabLink.vue
@@ -75,6 +75,8 @@ export default {
 
   .label {
     margin-top: 8px;
+    font-size: 16px;
+    font-weight: bold;
     color: $color-gray;
   }
 

--- a/src/components/PreventMeasureTabLink.vue
+++ b/src/components/PreventMeasureTabLink.vue
@@ -74,9 +74,8 @@ export default {
   }
 
   .label {
+    @include noto-font-001em(16px, bold);
     margin-top: 8px;
-    font-size: 16px;
-    font-weight: bold;
     color: $color-gray;
   }
 

--- a/src/components/PreventMeasureTabPanel.vue
+++ b/src/components/PreventMeasureTabPanel.vue
@@ -103,14 +103,13 @@ export default {
     flex: auto;
 
     h3 {
+      @include noto-font-001em(24px, bold);
       position: relative;
       margin: 0;
-      font-size: 24px;
-      font-weight: bold;
       color: $color-navy;
 
       @media (max-width: 960px) {
-        font-size: 16px;
+        @include noto-font-001em(16px, bold);
       }
 
       &::after {
@@ -130,24 +129,24 @@ export default {
     }
 
     p {
+      @include noto-font-001em(16px, normal);
       margin: 32px 0 0;
-      font-size: 16px;
 
       strong {
         font-weight: bold;
       }
 
       @media (max-width: 960px) {
-        font-size: 14px;
+        @include noto-font-001em(14px, normal);
       }
     }
   }
 
   .measure-cite {
+    @include noto-font-001em(12px, normal);
     margin-top: 40px;
     text-align: left;
     color: $color-gray;
-    font-size: 12px;
     word-break: break-word;
 
     h4 {


### PR DESCRIPTION
## 🍗 注意
このPRの向き先は `develop/1010` です

## 変更点
* ニュースのhoverの時、文章の部分の色が変わらないように
* 予防対策のtabの文字 font-size / font-weight 設定
* Safari で他の部分と文字スタイルの差を防ぐため、mixin を使うように