### PR TITLE
予防対策の画像の上に `margin-top` 追加

### DIFF
--- a/src/components/PreventMeasureTabPanel.vue
+++ b/src/components/PreventMeasureTabPanel.vue
@@ -90,6 +90,7 @@ export default {
     }
 
     @media (max-width: 960px) {
+      margin-top: 24px;
       width: 100%;
       max-width: 356px;
     }


### PR DESCRIPTION
[Slack Message](https://bitvalley-covid19.slack.com/archives/C0103PWD002/p1584809495023500)

<img width="478" alt="スクリーンショット 2020-03-22 3 35 10" src="https://user-images.githubusercontent.com/7374506/77233987-8e2e2a00-6bee-11ea-8161-b804241a4eb6.png">
